### PR TITLE
added ResourceRecordSet asset type to location exemption list

### DIFF
--- a/05-data-location/05_01-data-location.rego
+++ b/05-data-location/05_01-data-location.rego
@@ -75,6 +75,7 @@ exempt_resources := [
   "securitycenter.googleapis.com/MuteConfig",
   "securitycentermanagement.googleapis.com/SecurityCenterService",
   "storagetransfer.googleapis.com/TransferJob",
+  "dns.googleapis.com/ResourceRecordSet",
 ]
 
 # METADATA


### PR DESCRIPTION
Added `dns.googleapis.com/ResourceRecordSet` asset type to exemption list for location policy as it is being capture as a `global` entry and can't be changed to be region specific.